### PR TITLE
Make buttons work on Work screen and various other UI things

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -1,7 +1,7 @@
 import settingGroups from "./setting-groups.js";
 import settingDescriptions from "./setting-descriptions.js";
 import settingToComponentMap from "./setting-components.js";
-import { wakeLock } from "./pwa.js"
+import { wakeLock } from "./pwa.js";
 
 const getLocalStorageValue = (key, defaultValue) => {
   const value = localStorage.getItem(key);
@@ -13,33 +13,44 @@ const getLocalStorageValue = (key, defaultValue) => {
 
 export default {
   data: () => ({
-    settings: { },
+    settings: {},
     groups: settingGroups,
     saveToFlash: false,
     isBusy: false,
-    info : {},
+    info: {},
     socket: null,
-    error: '',
+    error: "",
     isHintVisible: false,
-    liveDataRaw: { },
+    liveDataRaw: {},
+    isHolding: false,
+    preventClick: false,
+    presets: [],
+    peakWatts: 0.0,
   }),
   computed: {
     liveData() {
       if (Object.keys(this.liveDataRaw).length < 1) return {};
       return {
-        'LiveTemp': this.liveDataRaw.LiveTemp,
-        'Voltage': (this.liveDataRaw.Voltage * 0.1).toFixed(1),
-        'HandleTemp': (this.liveDataRaw.HandleTemp * 0.1).toFixed(1),
-        'OperatingMode': this.liveDataRaw.OperatingMode,
-        'Watts': (this.liveDataRaw.Watts * 0.1).toFixed(1),
-      }
+        "LiveTemp": this.liveDataRaw.LiveTemp,
+        "Voltage": (this.liveDataRaw.Voltage * 0.1).toFixed(1),
+        "HandleTemp": (this.liveDataRaw.HandleTemp * 0.1).toFixed(1),
+        "OperatingMode": this.liveDataRaw.OperatingMode,
+        "Watts": (this.liveDataRaw.Watts * 0.1).toFixed(1),
+        "PeakWatts": (this.peakWatts).toFixed(1),
+      };
     },
   },
   methods: {
     getLocalGroupVisibilities() {
-      for(const group of this.groups) {
-        group.isVisible = getLocalStorageValue(`setting-${group.name}-visible`, true);
+      for (const group of this.groups) {
+        group.isVisible = getLocalStorageValue(
+          `setting-${group.name}-visible`,
+          true,
+        );
       }
+    },
+    getLocalTemperaturePresets() {
+      this.presets = getLocalStorageValue(`presets`, ["315", "365"]);
     },
     parseSettings(rawSettings) {
       for (const name in rawSettings) {
@@ -48,19 +59,20 @@ export default {
           value,
           lastSent: value,
           display: settingDescriptions[name]?.displayText ?? name,
-          hint: settingDescriptions[name]?.description ?? '',
+          hint: settingDescriptions[name]?.description ?? "",
           component: settingToComponentMap[name],
           showRawValue: false,
           isUpdating: false,
-        }
-        const isBooleanField = settingToComponentMap[name]?.name === 'checkbox';
+        };
+        const isBooleanField = settingToComponentMap[name]?.name === "checkbox";
         if (isBooleanField) {
           this.settings[name].value = value === 1;
         }
-        const isRapidlyChangingField = settingToComponentMap[name]?.name === 'range';
+        const isRapidlyChangingField =
+          settingToComponentMap[name]?.name === "range";
         if (!isRapidlyChangingField) {
           this.$watch(`settings.${name}.value`, (value) => {
-              this.updateSetting(name, value);
+            this.updateSetting(name, value);
           });
         }
         this.$watch(`settings.${name}.showRawValue`, (isShow) => {
@@ -70,32 +82,135 @@ export default {
             });
           }
         });
-        if (name === 'SettingsReset') {
-          const advanced = this.groups.find(group => group.name === 'Advanced settings');
-          if (advanced.items.indexOf('SettingsReset')<0) advanced.items.push('SettingsReset');
+        if (name === "SettingsReset") {
+          const advanced = this.groups.find((group) =>
+            group.name === "Advanced settings"
+          );
+          if (advanced.items.indexOf("SettingsReset") < 0) {
+            advanced.items.push("SettingsReset");
+          }
         }
       }
       this.setTemperatureRanges();
-      this.toggleVoltageSettings(this.settings['DCInCutoff'].value);
+      this.toggleVoltageSettings(this.settings["DCInCutoff"].value);
     },
-    confirm(name){
-      const yes = window.confirm('Are you sure?');
-      if (yes && name === 'SettingsReset') {
-          this.updateSetting(name, 1);
+    confirm(name, message = "Are you sure?", callback = false) {
+      const yes = window.confirm(message);
+      if (yes && name === "SettingsReset") {
+        this.updateSetting(name, 1);
+      } else if (yes && name == "SetPreset") {
+        if (callback) {
+          callback();
+        }
       }
     },
     toggleGroup(group) {
       group.isVisible = !group.isVisible;
       localStorage.setItem(`setting-${group.name}-visible`, group.isVisible);
     },
-    setTemperatureRanges(convertValue=false) {
+    setExactTemperature(event, idx) {
+      const setTemp = this.$refs["SetTemperature"][0].value;
+
+      var preset = this.$refs[`preset-${idx}`][0];
+
+      // console.log(event.type);
+      // console.log(this.isHolding);
+      // console.log(this.presets[idx]);
+      // console.log(setTemp);
+
+      var _this = this;
+      switch (event.type) {
+        case "mousedown":
+        case "touchstart":
+          this.isHolding = setTimeout(function () {
+            if (_this.isHolding) {
+              _this.confirm(
+                "SetPreset",
+                `Are you sure you wish to set this preset to ${setTemp}?`,
+                () => _this.presets[idx] = setTemp,
+              );
+              localStorage.setItem("presets", JSON.stringify(_this.presets));
+            }
+          }, 1000);
+          break;
+        case "click":
+          const presetTemp = preset.ariaValueNow;
+          console.log(preset);
+          console.log(presetTemp);
+          this.settings["SetTemperature"].value = presetTemp;
+          this.updateSetting(
+            "SetTemperature",
+            this.settings["SetTemperature"].value,
+          );
+        default:
+          clearTimeout(this.isHolding);
+          this.isHolding = false;
+          break;
+      }
+    },
+    setTemperature(multiplier, event) {
+      const settingName = "SetTemperature";
+      const setTemp = Number(this.$refs[settingName][0].value);
+
+      var _this = this;
+      var newTemp = setTemp;
+
+      var getStep = function (stepType) {
+        if (!["Long", "Short"].includes(stepType)) {
+          return NaN;
+        }
+        return Number(_this.settings[`TempChange${stepType}Step`].value);
+      };
+
+      var update = function (stepType) {
+        newTemp += multiplier * getStep(stepType);
+        _this.settings[settingName].value = newTemp;
+      };
+
+      // console.log(event.type);
+      // console.log(this.preventClick);
+
+      // mousdown -> mouseup -> click
+      switch (event.type) {
+        case "mousedown":
+        case "touchstart":
+          _this.isHolding = setTimeout(function () {
+            // Wait 1000ms, then start increasing by Long value every 500ms until release.
+            _this.preventClick = true;
+            if (_this.isHolding) {
+              _this.isHolding = setInterval(function () {
+                update("Long");
+              }, 500);
+            }
+          }, 1000);
+          break;
+        case "click":
+          if (!this.preventClick) {
+            update("Short");
+          }
+          this.preventClick = false;
+          // **intentionally** fall down into default
+        default:
+          clearTimeout(this.isHolding);
+          clearInterval(this.isHolding);
+          console.log(
+            "Sending new SetTemperature setting to device: ",
+            this.settings["SetTemperature"].value,
+          );
+          this.updateSetting(
+            "SetTemperature",
+            this.settings["SetTemperature"].value,
+          );
+      }
+    },
+    setTemperatureRanges(convertValue = false) {
       const ranges = {
-        0 : {
+        0: {
           BoostTemperature: [250, 450],
           SetTemperature: [10, 450],
           SleepTemperature: [10, 300],
         },
-        1 : {
+        1: {
           BoostTemperature: [480, 840],
           SetTemperature: [60, 850],
           SleepTemperature: [60, 580],
@@ -104,26 +219,30 @@ export default {
       const converter = {
         0: (value) => Math.round((value - 32) * 5 / 9),
         1: (value) => Math.round(value * 9 / 5 + 32),
-      }
-      const unit = this.settings['TemperatureUnit'].value;
+      };
+      const unit = this.settings["TemperatureUnit"].value;
       for (const setting in ranges[unit]) {
-        const [tMin,tMax] = ranges[unit][setting];
+        const [tMin, tMax] = ranges[unit][setting];
         this.settings[setting].component.min = tMin;
         this.settings[setting].component.max = tMax;
-        const isBoostTempOff = setting === 'BoostTemperature' && this.settings['BoostTemperature'].value === 0;
+        const isBoostTempOff = setting === "BoostTemperature" &&
+          this.settings["BoostTemperature"].value === 0;
         if (convertValue && !(isBoostTempOff)) {
-          this.settings[setting].value = Math.max(tMin, Math.min(tMax,converter[unit](this.settings[setting].value)));
+          this.settings[setting].value = Math.max(
+            tMin,
+            Math.min(tMax, converter[unit](this.settings[setting].value)),
+          );
         }
       }
     },
     toggleVoltageSettings(value) {
-      const classHidden = value ? '' : 'is-hidden';
-      this.settings['MinVolCell'].component.class = classHidden;
+      const classHidden = value ? "" : "is-hidden";
+      this.settings["MinVolCell"].component.class = classHidden;
     },
     isValueOutOfLimits(name, value) {
-      const {min, max, offable=false} = this.settings[name].component;
-      const isMinSet = typeof min !== 'undefined';
-      const isMaxSet = typeof max !== 'undefined';
+      const { min, max, offable = false } = this.settings[name].component;
+      const isMinSet = typeof min !== "undefined";
+      const isMaxSet = typeof max !== "undefined";
       const isBelowMin = isMinSet && value < min;
       const isAboveMax = isMaxSet && value > max;
       return isAboveMax || isBelowMin && !(offable && value == 0);
@@ -132,28 +251,35 @@ export default {
       if (this.settings[name].isUpdating) return;
       this.settings[name].isUpdating = true;
       if (this.isValueOutOfLimits(name, value)) {
-        const {min, max} = this.settings[name].component;
+        const { min, max } = this.settings[name].component;
         this.error = `Value for ${name} is out of range (${min} - ${max})`;
         this.settings[name].value = this.settings[name].lastSent;
         this.settings[name].isUpdating = false;
         return;
       }
-      if (this.settings[name].showRawValue) this.settings[name].showRawValue=false;
+      if (this.settings[name].showRawValue) {
+        this.settings[name].showRawValue = false;
+      }
       value = Number(value);
       if (this.settings[name].lastSent === value) {
         this.settings[name].isUpdating = false;
         return;
       }
       this.checkSocket()
-      .then(() => {
-        this.socket.send(JSON.stringify({command: "UPDATE_SETTING", payload: {name, value, save: this.saveToFlash}}));
-        this.settings[name].lastSent = value;
-      })
-      .finally(() => this.settings[name].isUpdating = false);
-      const changedTempUnit = name === 'TemperatureUnit';
-      const changedDCtype = name === 'DCInCutoff';
+        .then(() => {
+          this.socket.send(
+            JSON.stringify({
+              command: "UPDATE_SETTING",
+              payload: { name, value, save: this.saveToFlash },
+            }),
+          );
+          this.settings[name].lastSent = value;
+        })
+        .finally(() => this.settings[name].isUpdating = false);
+      const changedTempUnit = name === "TemperatureUnit";
+      const changedDCtype = name === "DCInCutoff";
       if (changedTempUnit) this.setTemperatureRanges(true);
-      if (changedDCtype) this.toggleVoltageSettings(value)
+      if (changedDCtype) this.toggleVoltageSettings(value);
       this.settings[name].isUpdating = false;
     },
     checkSocket() {
@@ -171,17 +297,17 @@ export default {
     },
     fetchSettings() {
       this.checkSocket()
-      .then(() => {
-        this.socket.send(JSON.stringify({command: "GET_SETTINGS"}));
-      });
+        .then(() => {
+          this.socket.send(JSON.stringify({ command: "GET_SETTINGS" }));
+        });
     },
     fetchInfo() {
       this.checkSocket()
-      .then(() => {
-        this.socket.send(JSON.stringify({command: "GET_INFO"}));
-      });
+        .then(() => {
+          this.socket.send(JSON.stringify({ command: "GET_INFO" }));
+        });
     },
-    initSocket(fetchData=true) {
+    initSocket(fetchData = true) {
       this.isBusy = true;
       this.socket = new WebSocket(`ws://${window.location.hostname}:12999/`);
       this.socket.onopen = () => {
@@ -193,9 +319,9 @@ export default {
       };
       this.socket.onmessage = (event) => {
         this.isBusy = false;
-        const data = JSON.parse(event.data)
-        if (data.status == 'ERROR') {
-          console.warn('error!', data);
+        const data = JSON.parse(event.data);
+        if (data.status == "ERROR") {
+          console.warn("error!", data);
           this.error = data.message;
           return;
         }
@@ -205,25 +331,34 @@ export default {
         if (data.command === "GET_INFO") {
           this.info = data.payload;
         }
-        if (data.command === 'LIVE_DATA') {
+        if (data.command === "LIVE_DATA") {
           this.liveDataRaw = data.payload;
+          const watts = this.liveData["Watts"];
+          if (watts > this.peakWatts) {
+            console.log("doing stuff");
+            this.peakWatts = Math.max(watts, this.peakWatts);
+          }
         }
       };
       this.socket.onclose = () => {
         this.isBusy = false;
-        console.log('socket closed');
+        console.log("socket closed");
       };
       this.socket.onerror = (e) => {
         this.isBusy = false;
-        this.error = 'Error connecting to backend. Make sure the server is running.'
-        console.warn('error!', e);
+        this.error =
+          "Error connecting to backend. Make sure the server is running.";
+        console.warn("error!", e);
       };
     },
   },
   mounted() {
     this.getLocalGroupVisibilities();
+    this.getLocalTemperaturePresets();
     this.initSocket();
-    wakeLock.request().then(lock => { this.awake = lock; });
+    wakeLock.request().then((lock) => {
+      this.awake = lock;
+    });
   },
   beforeUnmount() {
     wakeLock.release(this.awake);

--- a/ui/main.css
+++ b/ui/main.css
@@ -180,11 +180,36 @@ input[type=number] {
 .live-temp .plus {
   right:0;
 }
-.live-power {
-  width: 160px;
-  height:100px;
-  font-size: 2.5em;
+.info-row {
+  display:flex;
+  flex-wrap: wrap;
+  justify-content: stretch;
+  align-content: stretch;
+  height: 100px;
+  width: 320px;
+}
+.row-item {
+  min-width: 33.33%;
+  height: 50%;
+  font-size: 1.2em;
   border: 1px solid #c0cbcd;
-  padding-top:0.45em;
-  text-align:center;
+  /* padding-top:0.45em; */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.row-item i {
+  font-size:1.2em; 
+  font-weight:600; 
+  margin-right: 0.4em;
+}
+div.preset {
+  border-radius: 0;
+  border-color: #c0cbcd !important;
+  width: 50%;
+  height: 75px;
+}
+span.preset {
+  font-size: 1.7em;
 }

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -58,20 +58,50 @@
         >{{info.name}} <div class="is-hidden-desktop is-inline mr-6 pr-4">&nbsp;</div></h5>
       </div>
     </div>
-    <div class="is-flex is-justify-content-center mb-5 hide-until-load" :style="{'visibility':'visible'}">
+    <div class="is-flex is-justify-content-center mb-6 hide-until-load" :style="{'visibility':'visible'}">
       <div class="temp-holder" style="pointer-events: auto;">
         <div class="live-temp">
-          <button class="button change minus"> <i class="fas fa-minus"></i> </button>
-          <button class="button change plus"> <i class="fas fa-plus"></i> </button>
-          <div style="font-size:0.3em; margin-bottom:0.8em">SET: {{settings?.SetTemperature?.value}}&deg;C</div>
-          <i class="fa fa-thermometer-quarter"></i> <span style="font-weight:500">{{liveData.LiveTemp}}</span>&deg;C
-          <div style="font-size:0.3em; margin-top:0.4em">CURRENT TEMPERATURE</div>
+          <div class="buttons are-large">
+            <button class="button change minus" @click="setTemperature(-1, $event)" @touchstart="setTemperature(-1, $event)" @mousedown="setTemperature(-1, $event)" @touchleave="setTemperature(0, $event)" @mouseleave="setTemperature(0, $event)" @mouseup="setTemperature(0, $event)" @touchend="setTemperature(0, $event)"> <i class="fas fa-minus"></i> </button>
+            <button class="button change plus"  @click="setTemperature(1, $event)" @touchstart="setTemperature(1, $event)" @mousedown="setTemperature(1, $event)"  @mouseleave="setTemperature(0, $event)" @mouseup="setTemperature(0, $event)" @touchend="setTemperature(0, $event)"> <i class="fas fa-plus"></i> </button>
+          </div>
+          <div style="font-size:0.3em; margin-top:-1.8em; margin-bottom:0.8em" >SET {{settings.SetTemperature.value}}&deg;{{settings.TemperatureUnit.value ? 'F' : 'C'}}</div>
+            <i class="fa fa-thermometer-quarter"></i> <span style="font-weight:500">{{liveData.LiveTemp}}</span>&deg;{{settings.TemperatureUnit.value ? 'F' : 'C'}}
+          <div style="font-size:0.2em; margin-top:-1em">CURRENT</div>
         </div>
-        <div class="live-power">
-          <i class="fa fa-bolt" style="font-size:0.6em; font-weight:600;"></i> {{liveData.Watts}} W
-        </div>
-        <div class="live-power">
-          <i class="fa fa-plug" style="font-size:0.6em; font-weight:600;"></i> {{liveData.Voltage}} V
+        <div class="info-row">
+          <div class="row-item">
+              <div class="icon-text">
+                <span class="icon has-text-dark" style="width: 100%;">
+                  <i class="fas fa-angle-double-up"></i> 
+                  <span>{{liveData.PeakWatts}} W</span>
+                </span>
+              </div>
+          </div>
+          <div class="row-item">
+              <div class="icon-text">
+                <span class="icon has-text-dark" style="width: 100%;">
+                  <i class="fa fa-bolt"></i> 
+                  <span>{{liveData.Watts}} W</span>
+                </span>
+              </div>
+          </div>
+          <div class="row-item">
+              <div class="icon-text">
+                <span class="icon has-text-dark" style="width: 100%;">
+                  <i class="fa fa-plug"></i> 
+                  <span>{{liveData.Voltage}} V</span>
+                </span>
+              </div>
+          </div>
+            <div v-for="(preset, idx) in presets" :aria-valuenow="preset" :ref=`preset-${idx}` class="row-item preset button is-info is-light"  @click="setExactTemperature($event, idx)" @mousedown="setExactTemperature($event, idx)" @touchstart="setExactTemperature($event, idx)">
+              <div class="icon-text has-text-info">
+                <span class="icon is-large">
+                  <i class="fas fa-thermometer-half"></i>
+                  <span class="preset">{{preset}}</span>
+                </span>
+              </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Work screen improvements and functionality implmementation

Closes #32

- Make plus/minus buttons control set temperature as per Short/Long
  press parameters. Tapping the buttons once change the set point by
  TempChangeShortStep. Holding them changes the set point by
  TempChangeLongStep
- Work Screen changed to add preset buttons which immediately set the
  iron to the specified temperature. Holding down this button will
  prompt to confirm setting a new preset value using the current
  SetPoint.
- Presets are stored in localstorage in the browser
- Peak wattage is displayed alongside other live data
- display proper temperature based on setting

