### PR TITLE
Added logic to call xdg-open instead of open on linux

### DIFF
--- a/ci/start.sh
+++ b/ci/start.sh
@@ -23,7 +23,12 @@ pid1=$!
 pid2=$!
 
 sleep 5
-open http://localhost:8080/
+
+if [ "$(uname)" == "Darwin" ]; then
+    open http://localhost:8080/
+else
+    xdg-open http://localhost:8080/
+fi
 
 trap "kill $pid1 $pid2" EXIT
 wait $pid1 $pid2

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -13,7 +13,12 @@ pid2=$!
 cd ..
 
 sleep 2
-open http://localhost:8080/
+
+if [ "$(uname)" == "Darwin" ]; then
+    open http://localhost:8080/
+else
+    xdg-open http://localhost:8080/
+if
 
 trap "kill $pid1 $pid2" EXIT
 wait $pid1 $pid2


### PR DESCRIPTION
## Description

**Fixed to go from dev branch into dev branch**

This changes the files run-dev.sh and ci/start.sh to instead of calling open directly check if it is running on a darwin system.

If it is it will proceed with the previous open command however if it is on a linux system it will call xdg-open instead. 

This is because the open command doesn't exist on linux and is just called xdg-open.

This will not work on extremely minimal setups so i do think it would be good to still mention localhost:8080 in the install section however it will enable it to work on 95% of systems. 

## Related Issues

https://github.com/builder555/PineSAM/issues/136


## Screenshots

![image](https://user-images.githubusercontent.com/77225642/228829986-d8c3a214-7f91-44fd-a910-537edc599c22.png)


## Checklist

- [x ] I have tested my changes locally and they work as expected. 
**I do not have a macos system however as i am following the same if check as line 10 of the start.sh script i see no reason for it to not work.**
- [ x] I have updated the documentation, if applicable.
- [x ] I have added appropriate tests, if applicable.
- [x ] I have run the linter and fixed any issues, if applicable.