### PR TITLE
fix: remove xargs from start.sh

### DIFF
--- a/ci/start.sh
+++ b/ci/start.sh
@@ -13,7 +13,7 @@ if [ "$(uname)" == "Darwin" ]; then
     # this is needed because the mac will not execute binaries that are downloaded from the internet
     # see https://developer.apple.com/library/archive/technotes/tn2459/_index.html
     if xattr -p com.apple.quarantine ./PineSAM >/dev/null 2>&1; then
-        xargs xattr -rd com.apple.quarantine ./PineSAM 
+        xattr -rd com.apple.quarantine ./PineSAM
     fi
 fi
 


### PR DESCRIPTION
<!-- PLEASE MAKE PULL REQUESTS TO dev BRANCH -->
## Description

From personal testing, using `xargs` in the command to remove quarantine attributes from the `PineSAM` binary results in the command getting stuck indefinitely. I don't believe `xargs` is needed here anyways since we're not piping in any input.

I tested the script after removing `xargs`. The `xattr` command runs successfully after the change.

## Related Issues

N/A

## Screenshots

N/A

## Checklist

- [x] I have tested my changes locally and they work as expected.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate tests, if applicable.
- [x] I have run the linter and fixed any issues, if applicable.

## Other information

My editor did change the newline at the end of file, please let me know if that is an issue and I will fix it :)