### PR TITLE
feat: add macos x86 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,12 @@ jobs:
         include:
           - os: macos-latest
             TARGET: MacOS
-            ARCHITECTURE: x64
+            ARCHITECTURE: aarch64
+            BUILD_CMD: ci/build.sh
+            PACKAGE_CMD: ci/package.sh
+          - os: macos-13
+            TARGET: MacOS
+            ARCHITECTURE: x86_64
             BUILD_CMD: ci/build.sh
             PACKAGE_CMD: ci/package.sh
           - os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,12 +86,12 @@ jobs:
         include:
           - os: macos-latest
             TARGET: MacOS
-            ARCHITECTURE: aarch64
+            ARCHITECTURE: arm64
             BUILD_CMD: ci/build.sh
             PACKAGE_CMD: ci/package.sh
           - os: macos-13
             TARGET: MacOS
-            ARCHITECTURE: x86_64
+            ARCHITECTURE: Intel
             BUILD_CMD: ci/build.sh
             PACKAGE_CMD: ci/package.sh
           - os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 ---
-name: Buld a release
+name: Build a release
 
 on:
   pull_request:


### PR DESCRIPTION
<!-- PLEASE MAKE PULL REQUESTS TO dev BRANCH -->
## Description

Please refer to the [Github Actions Runner Docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) for more background.

Currently, [releases](https://github.com/builder555/PineSAM/releases) only provides prebuilt binaries for m-series (arm64) MacOS. This is because the `macos-latest` runner is based on the `arm64` architecture. 

This is in contrast to the other runners `ubuntu-latest` and `windows-latest`, that are based on `x86_64`.

This PR adds `macos-13` as a runner, which is based on `x86_64`. The `ARCHITECTURE` field is updated to match the `Architecture` field linked in the docs above.

I ran the actions pipeline on my fork to confirm that the binaries still build with the changes, but please feel free to test until satisfied. My actions run can be found [here](https://github.com/dotzenith/PineSAM/actions/runs/13211865100).

## Related Issues

N/A

## Screenshots

Before:
<img width="678" alt="before" src="https://github.com/user-attachments/assets/057a959d-46ab-45f9-88b4-9a2c842d5a3c" />

After:
<img width="1411" alt="after" src="https://github.com/user-attachments/assets/94561450-4017-4880-8147-3a125964b2fc" />

## Checklist

- [x] I have tested my changes locally and they work as expected.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate tests, if applicable.
- [x] I have run the linter and fixed any issues, if applicable.

## Other information

Please feel free to close the PR if you wish to not support different architectures for MacOS. I figured it would be easy enough to support both since Github supports both architectures for MacOS.
