### PR TITLE
chore: update intel mac os runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
             ARCHITECTURE: arm64
             BUILD_CMD: ci/build.sh
             PACKAGE_CMD: ci/package.sh
-          - os: macos-13
+          - os: macos-15-intel
             TARGET: MacOS
             ARCHITECTURE: Intel
             BUILD_CMD: ci/build.sh


### PR DESCRIPTION
## Description

Github is discontinuing `macos-13` runners, which is what PineSAM currently uses to create builds for Intel MacOS. They recommend using `macos-15-intel`, which will continue to work until Fall of 2027, at which point PineSAM can just stop offering builds for Intel MacOS.

See: [GitHub Actions: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) 

## Related Issues

N/A

## Screenshots

N/A

## Checklist

- [x] I have tested my changes locally and they work as expected.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate tests, if applicable.
- [x] I have run the linter and fixed any issues, if applicable.

## Other information

I tested the changes on my fork and they work as intended. The artifact built by the `macos-15-intel` runner was successfully tested on my 2020 Intel Macbook.
